### PR TITLE
Don't overwrite existing commands

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,8 +3,8 @@
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">
-                <item name="clear" xsi:type="object">Webfixit\OpCache\Console\Command\Clear</item>
-                <item name="status" xsi:type="object">Webfixit\OpCache\Console\Command\Status</item>
+                <item name="opcache_clear" xsi:type="object">Webfixit\OpCache\Console\Command\Clear</item>
+                <item name="opcache_status" xsi:type="object">Webfixit\OpCache\Console\Command\Status</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
In its current state this module will replace the `indexer:status` command.